### PR TITLE
Server-side auto refresh + better authorization API usage

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -65,11 +65,11 @@ function BitbucketApi (opts) {
   }
 
   function buildV1Req (endpoint) {
-    return new BitbucketRequest(buildUrl(_v1Prefix, endpoint)) // .accessToken(_accessToken)
+    return new BitbucketRequest(buildUrl(_v1Prefix, endpoint))
   }
 
   function buildV2Req (endpoint) {
-    return new BitbucketRequest(buildUrl(_v2Prefix, endpoint)) // .accessToken(_accessToken)
+    return new BitbucketRequest(buildUrl(_v2Prefix, endpoint))
   }
 
   // request methods: current user
@@ -87,13 +87,13 @@ function BitbucketApi (opts) {
 
   self.v2TeamsByRoleRequest = function v2TeamsByRoleRequest (role) {
     // roles: admin, contributor, member
-    return buildV2Req('/teams?role=' + role)
+    return buildV2Req('/teams').role(role || 'member')
   }
 
   // request methods: privileges
   self.v1PrivilegesRequest = function v1PrivilegesRequest (accountname, repo, filter) {
     // filters: read, write, admin
-    return buildV1Req('/privileges/' + accountname + '/' + repo + (filter ? '?filter=' + filter : ''))
+    return buildV1Req('/privileges/' + accountname + '/' + repo).filter(filter)
   }
 
   self.v1RepoPrivilegesForUserRequest = function v1RepoPrivilegesForUserRequest (accountname, repo, username) {
@@ -133,7 +133,7 @@ function BitbucketApi (opts) {
 
 function BitbucketRequest (url) {
   var self = this
-  var _accessToken, _user, _pass
+  var _accessToken, _user, _pass, _query
 
   self.accessToken = function accessToken (t) {
     if (t) _accessToken = t
@@ -158,6 +158,23 @@ function BitbucketRequest (url) {
     return self.username(u.username).password(u.password)
   }
 
+  self.query = function query (key, value) {
+    if (!_query) _query = {}
+    _query[key] = value
+    return self
+  }
+
+  // owner, admin, contributor, member
+  self.role = function role (r) {
+    if (r) self.query('role', r)
+    return self
+  }
+
+  self.filter = function filter (f) {
+    if (f) self.query('filter', f)
+    return self
+  }
+
   function buildGotOpts (method) {
     var opts = { json: true }
     if (method) opts.method = method
@@ -170,6 +187,9 @@ function BitbucketRequest (url) {
       opts.headers = {
         Authorization: 'Bearer ' + _accessToken
       }
+    }
+    if (_query) {
+      opts.query = _query
     }
     return opts
   }

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -25,22 +25,37 @@ function Authenticator (opts) {
 Authenticator.prototype.authenticate = function (credentials, cb) {
   if (!this._validateCredentials(credentials)) return Promise.reject(errors.forCode(500, 'Invalid credentials format')).nodeify(cb)
 
-  return this._authenticate(credentials.body).nodeify(cb)
+  return this._authenticate(credentials.body, false).nodeify(cb)
 }
 
-Authenticator.prototype._authenticate = function (credentialsBody) {
+Authenticator.prototype._authenticate = function (credentialsBody, storeUserData) {
   var getAuthToken = this._getAuthorizationToken(credentialsBody)
   var getSession = this._getSession(getAuthToken)
   var storeRefreshToken = this._storeRefreshToken(getSession, getAuthToken)
+  if (storeUserData) {
+    storeRefreshToken = Promise.join(storeRefreshToken, this._storeUserData(getSession, getAuthToken)).spread(function (result, ignore) {
+      return result
+    })
+  }
   return storeRefreshToken.return(getAuthToken)
 }
 
 Authenticator.prototype.unauthenticate = function (token, cb) {
+  // let npm-auth-ws delete the user data from redis
+  return this._unauthenticate(token, false).nodeify(cb)
+}
+
+Authenticator.prototype._unauthenticate = function (token, deleteUserData) {
   var getSession = this._getSession(true)
   var dropRefreshToken = this._dropRefreshToken(getSession, token)
+  if (deleteUserData) {
+    dropRefreshToken = Promise.join(dropRefreshToken, this._dropUserData(getSession, token)).spread(function (result, ignore) {
+      return result
+    })
+  }
   return dropRefreshToken.catch(function (err) {
     console.error(err) // basically ignore
-  }).nodeify(cb)
+  })
 }
 
 Authenticator.prototype._validateCredentials = function (credentials) {
@@ -107,9 +122,23 @@ Authenticator.prototype._storeRefreshToken = function (getSession, getAuthToken)
     })
 }
 
+Authenticator.prototype._storeUserData = function (getSession, getAuthToken) {
+  return Promise.join(getSession, getAuthToken)
+    .spread(function (session, authentication) {
+      if (!session || !authentication) return Promise.resolve(null)
+      return session.setUser(authentication.token, authentication.user)
+    })
+}
+
 Authenticator.prototype._dropRefreshToken = function (getSession, token) {
   return Promise.resolve(getSession).then(function (session) {
     return session.delRefreshToken(token)
+  })
+}
+
+Authenticator.prototype._dropUserData = function (getSession, token) {
+  return Promise.resolve(getSession).then(function (session) {
+    return session.delUser(token)
   })
 }
 

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -23,7 +23,7 @@ function Authenticator (opts) {
 }
 
 Authenticator.prototype.authenticate = function (credentials, cb) {
-  if (!this._validateCredentials(credentials)) return Promise.reject(errors.forCode(500, 'invalid credentials format')).nodeify(cb)
+  if (!this._validateCredentials(credentials)) return Promise.reject(errors.forCode(500, 'Invalid credentials format')).nodeify(cb)
 
   return this._authenticate(credentials.body).nodeify(cb)
 }

--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -169,9 +169,6 @@ Authorizer.prototype._getUser = function (getSession, token) {
   return Promise.resolve(getSession).then(function (session) {
     return session.getUser(token)
   })
-  .then(function (userData) {
-    return JSON.parse(userData)
-  })
 }
 
 Authorizer.prototype.end = function () {

--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -123,11 +123,14 @@ Authorizer.prototype._checkAuthorized = function (checkTeam, clientToken, scope)
     return Promise.resolve(getServerToken).then(function (token) {
       var getUser = self._getUser(getSession, token)
       return Promise.resolve(getUser).then(function (user) {
-        // get user-specific privileges and check against scope
-        var privilegesRequest = self.api.v1RepoPrivilegesForUserRequest(teamRepo.team, teamRepo.repo, user.name).accessToken(token)
-        var getPrivileges = Promise.resolve(privilegesRequest.get()).catch(function (err) {
+        // see if user has proper role for the specific repo in question
+        var reposRequest = self.api.v2RepositoriesRequest(teamRepo.team)
+          .role(scope === 'write' ? 'contributor' : 'member')
+          .query('q', 'full_name="' + teamRepo.team + '/' + teamRepo.repo + '"')
+          .accessToken(token)
+        var getRepos = Promise.resolve(reposRequest.get()).catch(function (err) {
           if (err.statusCode !== 401) {
-            console.error('Unexpected error from Bitbucket privileges API', err)
+            console.error('Unexpected error from Bitbucket repositories API', err)
             return Promise.reject(errors.forCode(err.statusCode, err.message))
           }
           // try refresh token
@@ -149,9 +152,9 @@ Authorizer.prototype._checkAuthorized = function (checkTeam, clientToken, scope)
               }, true))
               .then(function (auth) {
                 return Promise.join(
-                  self.authenticator._unauthenticate(token, true),
-                  Promise.resolve(session.setAlias(clientToken, auth.token)),
-                  privilegesRequest.accessToken(auth.token).get()
+                  self.authenticator._unauthenticate(token, true), // old token is no longer valid
+                  Promise.resolve(session.setAlias(clientToken, auth.token)), // associate client token to new token
+                  reposRequest.accessToken(auth.token).get() // try request again with new token
                 )
                 .spread(function (ignore1, ignore2, privileges) {
                   return privileges
@@ -172,14 +175,13 @@ Authorizer.prototype._checkAuthorized = function (checkTeam, clientToken, scope)
             })
           })
         })
-        return getPrivileges
-          .then(function (privileges) {
-            console.log('Privileges for ' + user.name + ' on repo ' + teamRepo.team + '/' + teamRepo.repo + ':', privileges)
-            if (privileges && privileges[0] && privileges[0].privilege) {
-              var p = privileges[0].privilege
-              return Promise.resolve(Boolean(p === 'admin' || p === 'write' || p === scope))
-            }
-            return Promise.resolve(false)
+        return getRepos
+          .then(function (repos) {
+            // since request is filtered to (1) a specific role and (2) a single repo,
+            // response will either have one paged record or none
+            var hasAccess = repos.size > 0
+            console.log('User %s has %s access to repo %s/%s?', user.name, scope, teamRepo.team, teamRepo.repo, hasAccess)
+            return Promise.resolve(hasAccess)
           })
           .catch(function (err) {
             console.error('Error checking authorization for ' + user.name + ' on repo ' + teamRepo.team + '/' + teamRepo.repo, err)

--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -36,7 +36,7 @@ Authorizer.prototype.authorize = function (credentials, cb) {
       scope = 'write'
       break
     default:
-      return Promise.reject(errors.forCode(405, 'unsupported method')).nodeify(cb)
+      return Promise.reject(errors.forCode(405, 'Unsupported method: ' + credentials.method)).nodeify(cb)
   }
 
   var packagePath = credentials.path
@@ -93,7 +93,7 @@ Authorizer.prototype._parseGitUrl = function (loadPackageJson) {
     if (url.match(/^(git:\/\/|git@)/)) url = parseGitUrl(url, { extraBaseUrls: /[^/]+/.source })
     var parsedUrl = urlParser.parse(url)
     var splitTeamRepo = parsedUrl.path.split('.git')[0].match(/^\/(.*)\/(.*)$/)
-    if (!splitTeamRepo) return Promise.reject(errors.forCode(400, 'does not appear to be a valid git url'))
+    if (!splitTeamRepo) return Promise.reject(errors.forCode(400, 'Does not appear to be a valid git url: ' + url))
     return {
       team: splitTeamRepo[1],
       repo: splitTeamRepo[2]
@@ -104,7 +104,7 @@ Authorizer.prototype._parseGitUrl = function (loadPackageJson) {
 Authorizer.prototype._checkTeam = function (parseGitUrl) {
   var self = this
   return Promise.resolve(parseGitUrl).then(function (teamRepo) {
-    if (self.bitbucketTeam && self.bitbucketTeam !== teamRepo.team) return Promise.reject(errors.forCode(400, 'repo not under team ' + self.bitbucketTeam))
+    if (self.bitbucketTeam && self.bitbucketTeam !== teamRepo.team) return Promise.reject(errors.forCode(400, 'Repo ' + teamRepo.repo + ' not under team ' + self.bitbucketTeam))
     return teamRepo
   })
 }
@@ -123,7 +123,7 @@ Authorizer.prototype._checkAuthorized = function (checkTeam, token, scope) {
         // try refresh token
         return Promise.resolve(getSession).then(function (session) {
           return Promise.resolve(session.getRefreshToken(token)).then(function (refreshToken) {
-            if (!refreshToken) return Promise.reject(errors.forCode(401, 'Please login again.'))
+            if (!refreshToken) return Promise.reject(errors.forCode(401, 'Please login again'))
             return Promise.resolve(self.authenticator._authenticate({
               email: user.email,
               name: user.name,
@@ -137,7 +137,7 @@ Authorizer.prototype._checkAuthorized = function (checkTeam, token, scope) {
             })
             .catch(function (error) {
               console.error(error)
-              return Promise.reject(errors.forCode(401, 'Refresh token expired. Please login again.'))
+              return Promise.reject(errors.forCode(401, 'Refresh token expired, please login again'))
             })
           })
         })

--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -167,7 +167,7 @@ Authorizer.prototype._getSession = function () {
 
 Authorizer.prototype._getUser = function (getSession, token) {
   return Promise.resolve(getSession).then(function (session) {
-    return session.getUser('user-' + token)
+    return session.getUser(token)
   })
   .then(function (userData) {
     return JSON.parse(userData)

--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -22,8 +22,8 @@ function Authorizer (opts) {
 }
 
 Authorizer.prototype.authorize = function (credentials, cb) {
-  var token = this._extractToken(credentials)
-  if (!token) return Promise.reject(errors.forCode(404)).nodeify(cb)
+  var clientToken = this._extractToken(credentials)
+  if (!clientToken) return Promise.reject(errors.forCode(404)).nodeify(cb)
 
   var scope
   switch (credentials.method) {
@@ -45,17 +45,20 @@ Authorizer.prototype.authorize = function (credentials, cb) {
   var loadPackageJson = this._loadPackageJson(packagePath, untrustedPackageJson)
   var parseGitUrl = this._parseGitUrl(loadPackageJson)
   var checkTeam = this._checkTeam(parseGitUrl)
-  var checkAuthorized = this._checkAuthorized(checkTeam, token, scope)
+  var checkAuthorized = this._checkAuthorized(checkTeam, clientToken, scope)
   return checkAuthorized.nodeify(cb)
 }
 
 Authorizer.prototype.whoami = function (credentials, cb) {
-  var token = this._extractToken(credentials)
-  if (!token) return Promise.reject(errors.forCode(404)).nodeify(cb)
+  var clientToken = this._extractToken(credentials)
+  if (!clientToken) return Promise.reject(errors.forCode(404)).nodeify(cb)
 
-  var getSession = this._getSession()
-  var getUser = this._getUser(getSession, token)
-  return getUser.nodeify(cb)
+  var self = this
+  var getSession = self._getSession()
+  var getServerToken = self._getServerToken(getSession, clientToken)
+  return Promise.resolve(getServerToken).then(function (token) {
+    return self._getUser(getSession, token)
+  }).nodeify(cb)
 }
 
 Authorizer.prototype._extractToken = function (credentials) {
@@ -82,6 +85,7 @@ Authorizer.prototype._loadPackageJson = function (packagePath, untrustedPackageJ
             return untrustedJson.versions[untrustedJson['dist-tags'].latest]
           })
         }
+        console.error('Unexpected error fetching package.json for ' + pkgPath, err)
         return Promise.reject(errors.forCode(err.statusCode))
       })
   })
@@ -109,50 +113,79 @@ Authorizer.prototype._checkTeam = function (parseGitUrl) {
   })
 }
 
-Authorizer.prototype._checkAuthorized = function (checkTeam, token, scope) {
+Authorizer.prototype._checkAuthorized = function (checkTeam, clientToken, scope) {
   var self = this
   return Promise.resolve(checkTeam).then(function (teamRepo) {
     // don't get session until we know checkTeam has not erred
     var getSession = self._getSession()
-    var getUser = self._getUser(getSession, token)
-    return Promise.resolve(getUser).then(function (user) {
-      // get user-specific privileges and check against scope
-      var privilegesRequest = self.api.v1RepoPrivilegesForUserRequest(teamRepo.team, teamRepo.repo, user.name).accessToken(token)
-      var getPrivileges = Promise.resolve(privilegesRequest.get()).catch(function (err) {
-        if (err.statusCode !== 401) return Promise.reject(errors.forCode(err.statusCode, err.message))
-        // try refresh token
-        return Promise.resolve(getSession).then(function (session) {
-          return Promise.resolve(session.getRefreshToken(token)).then(function (refreshToken) {
-            if (!refreshToken) return Promise.reject(errors.forCode(401, 'Please login again'))
-            return Promise.resolve(self.authenticator._authenticate({
-              email: user.email,
-              name: user.name,
-              refreshToken: refreshToken
-            }))
-            .then(function (auth) {
-              return Promise.join(self.authenticator.unauthenticate(token), privilegesRequest.accessToken(auth.token).get())
-                .spread(function (ignore, privileges) {
+    // swap client token for server token, in case we previously used a refresh token behind the scenes
+    var getServerToken = self._getServerToken(getSession, clientToken)
+    return Promise.resolve(getServerToken).then(function (token) {
+      var getUser = self._getUser(getSession, token)
+      return Promise.resolve(getUser).then(function (user) {
+        // get user-specific privileges and check against scope
+        var privilegesRequest = self.api.v1RepoPrivilegesForUserRequest(teamRepo.team, teamRepo.repo, user.name).accessToken(token)
+        var getPrivileges = Promise.resolve(privilegesRequest.get()).catch(function (err) {
+          if (err.statusCode !== 401) {
+            console.error('Unexpected error from Bitbucket privileges API', err)
+            return Promise.reject(errors.forCode(err.statusCode, err.message))
+          }
+          // try refresh token
+          return Promise.resolve(getSession).then(function (session) {
+            return Promise.resolve(session.getRefreshToken(token)).then(function (refreshToken) {
+              if (!refreshToken) {
+                return Promise.resolve(session.delAlias(clientToken))
+                  .catch(function (redisErr) {
+                    console.error('Ignoring redis error while attempting to delete alias: ' + clientToken, redisErr)
+                  })
+                  .then(function () {
+                    return Promise.reject(errors.forCode(401, 'Please login again'))
+                  })
+              }
+              return Promise.resolve(self.authenticator._authenticate({
+                email: user.email,
+                name: user.name,
+                refreshToken: refreshToken
+              }, true))
+              .then(function (auth) {
+                return Promise.join(
+                  self.authenticator._unauthenticate(token, true),
+                  Promise.resolve(session.setAlias(clientToken, auth.token)),
+                  privilegesRequest.accessToken(auth.token).get()
+                )
+                .spread(function (ignore1, ignore2, privileges) {
                   return privileges
                 })
-            })
-            .catch(function (error) {
-              console.error(error)
-              return Promise.reject(errors.forCode(401, 'Refresh token expired, please login again'))
+              })
+              .catch(function (error) {
+                console.error('Ignoring ambiguous error', error)
+                return Promise.join(session.delAlias(clientToken), session.delRefreshToken(token)).spread(function (delAliasResult, delRefreshResult) {
+                  return false
+                })
+                .catch(function (redisError) {
+                  console.error('Ignoring redis error on delete alias and refresh token: ' + clientToken, redisError)
+                })
+                .then(function () {
+                  return Promise.reject(errors.forCode(401, 'Refresh token expired, please login again'))
+                })
+              })
             })
           })
         })
+        return getPrivileges
+          .then(function (privileges) {
+            console.log('Privileges for ' + user.name + ' on repo ' + teamRepo.team + '/' + teamRepo.repo + ':', privileges)
+            if (privileges && privileges[0] && privileges[0].privilege) {
+              var p = privileges[0].privilege
+              return Promise.resolve(Boolean(p === 'admin' || p === 'write' || p === scope))
+            }
+            return Promise.resolve(false)
+          })
+          .catch(function (err) {
+            console.error('Error checking authorization for ' + user.name + ' on repo ' + teamRepo.team + '/' + teamRepo.repo, err)
+            return Promise.reject(errors.forCode(err.statusCode, err.message))
+          })
       })
-      return getPrivileges
-        .then(function (privileges) {
-          if (privileges && privileges[0] && privileges[0].privilege) {
-            var p = privileges[0].privilege
-            return Promise.resolve(Boolean(p === 'admin' || p === 'write' || p === scope))
-          }
-          return Promise.resolve(false)
-        })
-        .catch(function (err) {
-          return Promise.reject(errors.forCode(err.statusCode, err.message))
-        })
     })
   })
 }
@@ -165,9 +198,22 @@ Authorizer.prototype._getSession = function () {
   })
 }
 
+Authorizer.prototype._getServerToken = function (getSession, clientToken) {
+  return Promise.resolve(getSession).then(function (session) {
+    return session.getAlias(clientToken)
+  })
+  .then(function (serverToken) {
+    return serverToken || clientToken
+  })
+  .catch(function (err) {
+    console.error('Ignoring redis error on get alias: ' + clientToken, err)
+    return clientToken
+  })
+}
+
 Authorizer.prototype._getUser = function (getSession, token) {
   return Promise.resolve(getSession).then(function (session) {
-    return session.getUser(token)
+    return session.getUser(token, false)
   })
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,7 +1,7 @@
 var defaultMsg = {
-  500: 'unknown error',
-  401: 'unauthorized',
-  404: 'not found'
+  500: 'Unknown error',
+  401: 'Unauthorized',
+  404: 'Not found'
 }
 
 module.exports.forCode = function forCode (code, msg) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -17,6 +17,28 @@ function Session (opts) {
   this.client = opts.redisClient || redis.createClient(process.env.LOGIN_CACHE_REDIS)
 }
 
+Session.prototype.get = function (key, cb) {
+  if (/^user-/.test(key)) return this.getUser(key.substring(5), true).nodeify(cb)
+  return Promise
+    .promisify(this.client.get, { context: this.client })(key)
+    .then(function (jsonString) {
+      return JSON.parse(jsonString)
+    })
+    .nodeify(cb)
+}
+
+Session.prototype.set = function (key, session, cb) {
+  return Promise
+    .promisify(this.client.set, { context: this.client })(key, JSON.stringify(session))
+    .nodeify(cb)
+}
+
+Session.prototype.delete = function (key, cb) {
+  return Promise
+    .promisify(this.client.del, { context: this.client })(key)
+    .nodeify(cb)
+}
+
 Session.prototype.setRefreshToken = function (accessToken, refreshToken) {
   return Promise
     .promisify(this.client.set, { context: this.client })(refreshTokenKey(accessToken), refreshToken)
@@ -32,11 +54,31 @@ Session.prototype.delRefreshToken = function (accessToken) {
     .promisify(this.client.del, { context: this.client })(refreshTokenKey(accessToken))
 }
 
-Session.prototype.getUser = function (accessToken) {
+Session.prototype.setUser = function (accessToken, user) {
   return Promise
-    .promisify(this.client.get, { context: this.client })(userKey(accessToken))
-    .then(function (jsonString) {
-      return JSON.parse(jsonString)
+    .promisify(this.client.set, { context: this.client })(userKey(accessToken), JSON.stringify(user))
+}
+
+Session.prototype.getUser = function (accessToken, tryAlias) {
+  var self = this
+  // swap client token for server token, in case we previously used a refresh token behind the scenes
+  var getAlias = tryAlias ? self.getAlias(accessToken) : Promise.resolve(null)
+  return getAlias
+    .then(function (serverToken) {
+      console.error('serverToken:', serverToken)
+      console.error('accessToken:', accessToken)
+      return serverToken || accessToken
+    })
+    .catch(function (err) {
+      console.error('Ignoring redis error on get alias: ' + accessToken, err)
+      return accessToken
+    })
+    .then(function (token) {
+      return Promise
+        .promisify(self.client.get, { context: self.client })(userKey(token))
+        .then(function (jsonString) {
+          return JSON.parse(jsonString)
+        })
     })
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -5,6 +5,10 @@ function refreshTokenKey (accessToken) {
   return 'refresh-' + accessToken
 }
 
+function userKey (accessToken) {
+  return 'user-' + accessToken
+}
+
 function Session (opts) {
   this.client = opts.redisClient || redis.createClient(process.env.LOGIN_CACHE_REDIS)
 }
@@ -29,7 +33,7 @@ Session.prototype.delRefreshToken = function (accessToken, cb) {
 
 Session.prototype.getUser = function (accessToken, cb) {
   return Promise
-    .promisify(this.client.get, { context: this.client })(accessToken)
+    .promisify(this.client.get, { context: this.client })(userKey(accessToken))
     .nodeify(cb)
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -9,32 +9,55 @@ function userKey (accessToken) {
   return 'user-' + accessToken
 }
 
+function aliasKey (accessToken) {
+  return 'alias-' + accessToken
+}
+
 function Session (opts) {
   this.client = opts.redisClient || redis.createClient(process.env.LOGIN_CACHE_REDIS)
 }
 
-Session.prototype.setRefreshToken = function (accessToken, refreshToken, cb) {
+Session.prototype.setRefreshToken = function (accessToken, refreshToken) {
   return Promise
     .promisify(this.client.set, { context: this.client })(refreshTokenKey(accessToken), refreshToken)
-    .nodeify(cb)
 }
 
-Session.prototype.getRefreshToken = function (accessToken, cb) {
+Session.prototype.getRefreshToken = function (accessToken) {
   return Promise
     .promisify(this.client.get, { context: this.client })(refreshTokenKey(accessToken))
-    .nodeify(cb)
 }
 
-Session.prototype.delRefreshToken = function (accessToken, cb) {
+Session.prototype.delRefreshToken = function (accessToken) {
   return Promise
     .promisify(this.client.del, { context: this.client })(refreshTokenKey(accessToken))
-    .nodeify(cb)
 }
 
-Session.prototype.getUser = function (accessToken, cb) {
+Session.prototype.getUser = function (accessToken) {
   return Promise
     .promisify(this.client.get, { context: this.client })(userKey(accessToken))
-    .nodeify(cb)
+    .then(function (jsonString) {
+      return JSON.parse(jsonString)
+    })
+}
+
+Session.prototype.delUser = function (accessToken) {
+  return Promise
+    .promisify(this.client.del, { context: this.client })(userKey(accessToken))
+}
+
+Session.prototype.setAlias = function (clientToken, serverToken) {
+  return Promise
+    .promisify(this.client.set, { context: this.client })(aliasKey(clientToken), serverToken)
+}
+
+Session.prototype.getAlias = function (clientToken) {
+  return Promise
+    .promisify(this.client.get, { context: this.client })(aliasKey(clientToken))
+}
+
+Session.prototype.delAlias = function (clientToken) {
+  return Promise
+    .promisify(this.client.del, { context: this.client })(aliasKey(clientToken))
 }
 
 Session.prototype.end = function () {


### PR DESCRIPTION
Two big changes here:
1. Use of the refresh token on the server-side to automatically update the access token, which requires the server to maintain a mapping/alias for client token to actual API access token (since requests for authorization cannot update the client with a new token)
2. Update to how the Bitbucket API is used to determine read or write access to a particular repository (based on direction from Atlassian)

The code is fully functional now (for Bitbucket Cloud only) and could possibly be plugged in as an "official" strategy in npm On-Site. However, there are at least 2 additional issues I'd like to address:
- (a) More unit tests for better code coverage
- (b) Change authentication to always create an API token alias, like a UUID, and return the alias to the client instead of the access token

Neither of these is technically necessary, but they will both make long-term maintenance easier.
