### PR TITLE
Session constructor should work when opts not given

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -14,6 +14,7 @@ function aliasKey (accessToken) {
 }
 
 function Session (opts) {
+  opts = opts || {}
   this.client = opts.redisClient || redis.createClient(process.env.LOGIN_CACHE_REDIS)
 }
 


### PR DESCRIPTION
Otherwise `new Session()` would blow up unnecessarily.
